### PR TITLE
Mejoras y fixes en Rut validator

### DIFF
--- a/src/Rut.php
+++ b/src/Rut.php
@@ -4,11 +4,13 @@ namespace juanisorondo\ValidadorUruguay;
 
 class Rut
 {
-    public function validate($rut)
+    public static function validate($rut)
     {
-        if (strlen($rut) != 12 || !is_numeric($rut)) {
+        if (strlen($rut) > 12 || !is_numeric($rut)) {
             return false;
         }
+        $rut = strval($rut);
+        $rut = str_pad($rut,12,'0',STR_PAD_LEFT);
 
         $tmp = array_map('intval', str_split($rut));
 

--- a/src/Rut.php
+++ b/src/Rut.php
@@ -6,11 +6,10 @@ class Rut
 {
     public static function validate($rut)
     {
-        if (strlen($rut) > 12 || !is_numeric($rut)) {
+        if (strlen($rut) != 12 || !is_numeric($rut)) {
             return false;
         }
         $rut = strval($rut);
-        $rut = str_pad($rut,12,'0',STR_PAD_LEFT);
 
         $tmp = array_map('intval', str_split($rut));
 

--- a/tests/unit/RutTest.php
+++ b/tests/unit/RutTest.php
@@ -10,9 +10,7 @@ class RutTest extends Unit
      */
     public function testRuts($rut, $result)
     {
-        $validator = new Rut();
-        $this->assertInstanceOf(Rut::class, $validator);
-        $this->assertEquals($result, $validator->validate($rut));
+        $this->assertEquals($result, Rut::validate($rut));
     }
 
     public function ejemplos()
@@ -21,6 +19,8 @@ class RutTest extends Unit
             ['210475730011', true],
             ['310475730011', false],
             ['2104757300110', false],
+            ['20064100019', true],// 11 digitos
+            [217832560011, true],
         ];
     }
 }

--- a/tests/unit/RutTest.php
+++ b/tests/unit/RutTest.php
@@ -19,7 +19,7 @@ class RutTest extends Unit
             ['210475730011', true],
             ['310475730011', false],
             ['2104757300110', false],
-            ['20064100019', true],// 11 digitos
+            ['020064100019', true],
             [217832560011, true],
         ];
     }


### PR DESCRIPTION
- Se convierte a `static` la función para no tener que crear una instancia
- Se permiten RUTs que son números (no solo strings)