### PR TITLE
Cédulas solo 0s son inválidas

### DIFF
--- a/src/Ci.php
+++ b/src/Ci.php
@@ -24,7 +24,7 @@ class Ci
         }
         $numbers = str_pad($numbers, 8, '0', STR_PAD_LEFT);
 
-        if ($numbers === '00000000'){
+        if ($numbers === '00000000') {
             return false;
         }
 

--- a/src/Ci.php
+++ b/src/Ci.php
@@ -24,6 +24,10 @@ class Ci
         }
         $numbers = str_pad($numbers, 8, '0', STR_PAD_LEFT);
 
+        if ($numbers === '00000000'){
+            return false;
+        }
+
         $split = str_split($numbers);
         $coeffs = [2, 9, 8, 7, 6, 3, 4, 1];
 

--- a/src/Ci.php
+++ b/src/Ci.php
@@ -19,14 +19,10 @@ class Ci
         }
 
         $numbers = str_replace(['.', '-'], '', $ci);
-        if (strlen($numbers) > 8) {
+        if (!intval($numbers) || strlen($numbers) > 8) {
             return false;
         }
         $numbers = str_pad($numbers, 8, '0', STR_PAD_LEFT);
-
-        if ($numbers === '00000000') {
-            return false;
-        }
 
         $split = str_split($numbers);
         $coeffs = [2, 9, 8, 7, 6, 3, 4, 1];

--- a/tests/CiTest.php
+++ b/tests/CiTest.php
@@ -38,6 +38,8 @@ class CiTest extends TestCase
         $this->assertTrue(Ci::validate('7387538', Ci::NUMBERS));
         $this->assertTrue(Ci::validate('07387538', Ci::NUMBERS));
 
+        $this->assertFalse(Ci::validate('000', Ci::NUMBERS));
+        $this->assertFalse(Ci::validate('00000000', Ci::NUMBERS));
         $this->assertFalse(Ci::validate('12121211', Ci::NUMBERS));
         $this->assertFalse(Ci::validate('121212122', Ci::NUMBERS));
         $this->assertFalse(Ci::validate('628053', Ci::DOTS_HYPHEN));

--- a/tests/CiTest.php
+++ b/tests/CiTest.php
@@ -33,6 +33,7 @@ class CiTest extends TestCase
 
     public function testNumbers()
     {
+        $this->assertTrue(false);
         $this->assertTrue(Ci::validate('628050', Ci::NUMBERS));
         $this->assertTrue(Ci::validate('12121212', Ci::NUMBERS));
         $this->assertTrue(Ci::validate('7387538', Ci::NUMBERS));

--- a/tests/CiTest.php
+++ b/tests/CiTest.php
@@ -33,7 +33,6 @@ class CiTest extends TestCase
 
     public function testNumbers()
     {
-        $this->assertTrue(false);
         $this->assertTrue(Ci::validate('628050', Ci::NUMBERS));
         $this->assertTrue(Ci::validate('12121212', Ci::NUMBERS));
         $this->assertTrue(Ci::validate('7387538', Ci::NUMBERS));


### PR DESCRIPTION
Según las reglas de validación CIs como 0, 000, etc. son válidas ya que cumplen con las fórmulas.
En práctica son valores completamente ficticios e inválidos